### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "scripts": {
     "build-test": "gulp build:test",
     "build-cover": "npm run build-test -- --cover",
-    "test": "BABEL_ENV=test NODE_ENV=test && gulp test",
-    "fast-test": "NODE_ENV=test gulp run:test",
-    "cover": "NODE_ENV=test npm run build-cover && gulp test",
+    "test": "export BABEL_ENV=test export NODE_ENV=test && gulp test",
+    "fast-test": "export NODE_ENV=test gulp run:test",
+    "cover": "export NODE_ENV=test npm run build-cover && gulp test",
     "lint": "gulp lint",
     "watch": "gulp watch",
     "build": "gulp build",
-    "build-production": "NODE_ENV=production npm run build",
+    "build-production": "export NODE_ENV=production npm run build",
     "server": "gulp server"
   },
   "pre-commit": [


### PR DESCRIPTION
There was a bug in database path, and turns out it is related with ENV setting.
In OSX, Linux, to set NODE_ENV and BABEL_ENV "export" should be add in front of them. :)
