### PR TITLE
Hotfix/travis

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -93,8 +93,8 @@ gulp.task('run:test', ['build:test'], () => {
   }, (exitCode) => {
     if (exitCode !== 0) {
       console.error('Tests failed! - Test script exited with non-zero status code.');
-      return false;
     }
+    process.exitCode = exitCode;
     return true;
   });
   output.pipe(process.stdout);

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -93,6 +93,7 @@ gulp.task('run:test', ['build:test'], () => {
   }, (exitCode) => {
     if (exitCode !== 0) {
       console.error('Tests failed! - Test script exited with non-zero status code.');
+      return false;
     }
     return true;
   });

--- a/src/test/node/items/controllers.js
+++ b/src/test/node/items/controllers.js
@@ -396,7 +396,7 @@ test('delete all item from database', t => {
     }
 
     const expected = {
-      status: 200,
+      status: 20,
       message: 'success'
     };
 

--- a/src/test/node/items/controllers.js
+++ b/src/test/node/items/controllers.js
@@ -396,7 +396,7 @@ test('delete all item from database', t => {
     }
 
     const expected = {
-      status: 20,
+      status: 200,
       message: 'success'
     };
 


### PR DESCRIPTION
@ovekyc https://github.com/sv-bootcamp/goober/issues/56
It seem like the test exitcode is not returned after test is completed.
So, I return the exitcode in the gulp task run:test and now if test is failed travis is not passed.

[https://github.com/rtsao/unitest/blob/master/docs/api.md](https://github.com/rtsao/unitest/blob/master/docs/api.md)
[https://travis-ci.org/sv-bootcamp/goober/builds/166968463](https://travis-ci.org/sv-bootcamp/goober/builds/166968463)
