### PR TITLE
Heroku/postinstall

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm install --only=dev && gulp apidoc && npm run server
+web: npm run server

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "gulp build",
     "build-production": "NODE_ENV=production npm run build",
     "server": "gulp server",
-    "postinstall": "npm install --only=dev && gulp apidoc"
+    "postinstall": "gulp apidoc"
   },
   "pre-commit": [
     "test"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "watch": "gulp watch",
     "build": "gulp build",
     "build-production": "NODE_ENV=production npm run build",
-    "server": "gulp server"
+    "server": "gulp server",
+    "postinstall": "npm install --only=dev"
   },
   "pre-commit": [
     "test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "gulp build",
     "build-production": "NODE_ENV=production npm run build",
     "server": "gulp server",
-    "postinstall": "npm install --only=dev"
+    "postinstall": "npm install --only=dev && gulp apidoc"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
- there is a way to run gulp task before build that makes us not to worry about build time.
- [https://docs.npmjs.com/misc/scripts](https://docs.npmjs.com/misc/scripts)