### PR TITLE
Add error-handler to image-controller (GET)

### DIFF
--- a/src/server/images/controllers.js
+++ b/src/server/images/controllers.js
@@ -59,6 +59,7 @@ export default {
           message: 'Internal Database Error'
         }));
       });
+      return;
     } else if (image) {
       // get an images
       ImageManager.fetchImage([image], (errFetch, values) => {
@@ -75,7 +76,12 @@ export default {
         cb();
         return;
       });
+      return;
     }
+    cb(new APIError(new Error(), {
+      statusCode: 400,
+      message: 'Bad Request : No query string'
+    }));
   },
   post(req, res, cb) {
     assert(req.headers.userKey, 'userKey should be provided.');


### PR DESCRIPTION
Until now,
If we send request without query string to '/api/images'
It dose not send response.
So fix it with bad request (400)