### PR TITLE
Add property assertion to image/post

### DIFF
--- a/src/server/images/controllers.js
+++ b/src/server/images/controllers.js
@@ -78,7 +78,7 @@ export default {
     }
   },
   post(req, res, cb) {
-    assert(req.body.userKey, 'userKey should be provided.');
+    assert(req.headers.userKey, 'userKey should be provided.');
     assert(req.body.itemKey, 'itemKey should be provided.');
     const currentTime = new Date();
     const timeHash = KeyUtils.genTimeHash(currentTime);

--- a/src/server/images/controllers.js
+++ b/src/server/images/controllers.js
@@ -4,6 +4,7 @@ import {S3Connector} from '../aws-s3';
 import {APIError} from '../ErrorHandler';
 import ImageManager from './models';
 import {CreatedPostManager} from '../users/models';
+import assert from 'assert';
 
 export default {
   get(req, res, cb) {
@@ -77,6 +78,8 @@ export default {
     }
   },
   post(req, res, cb) {
+    assert(req.body.userKey, 'userKey should be provided.');
+    assert(req.body.itemKey, 'itemKey should be provided.');
     const currentTime = new Date();
     const timeHash = KeyUtils.genTimeHash(currentTime);
     const key = `${ENTITY.IMAGE}-${timeHash}`;


### PR DESCRIPTION
If client send image which will be posted without itemKey or userKey, It still be posted. 
But not appear anywhere. 
Because There is no information about created person and which event that it engaged in.